### PR TITLE
Add a moduleForApp helper to make setting up acceptance tests easier.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,6 +3,7 @@ import isolatedContainer  from './isolated-container';
 import moduleFor          from './module-for';
 import moduleForComponent from './module-for-component';
 import moduleForModel     from './module-for-model';
+import moduleForApp       from './module-for-app';
 import test               from './test';
 import testResolver       from './test-resolver';
 
@@ -16,6 +17,7 @@ function globalize() {
   window.moduleFor = moduleFor;
   window.moduleForComponent = moduleForComponent;
   window.moduleForModel = moduleForModel;
+  window.moduleForApp = moduleForApp;
   window.test = test;
   window.setResolver = setResolver;
 }
@@ -25,6 +27,7 @@ export {
   moduleFor,
   moduleForComponent,
   moduleForModel,
+  moduleForApp,
   test,
   setResolver
 };

--- a/lib/module-for-app.js
+++ b/lib/module-for-app.js
@@ -1,0 +1,61 @@
+var getUrlGenerator = function(App, name) {
+  var forEach = Ember.ArrayPolyfills.forEach,
+    filter = Ember.ArrayPolyfills.filter;
+
+  return function(params) {
+    var recognizer = App.__container__
+      .lookup('router:main')
+      .get('router.recognizer');
+    if (!(name in recognizer.names)) {
+      throw new Error('Route `' + name + '` not found');
+    }
+
+    var args = [].slice.call(arguments);
+
+    if (Ember.typeOf(params) === 'string' || args.length > 1) {
+      params = {};
+
+      var segments = recognizer.names[name].segments;
+
+      forEach.call(filter.call(segments, function(segment) {
+        return !!segment.name;
+      }), function(segment, i) {
+        if (!(i in args)) {
+          throw new Error('Not enough arguments passed for each Dynamic Segment');
+        }
+        params[segment.name] = args[i].toString();
+      });
+    }
+
+    return recognizer.generate(name, params);
+  };
+};
+
+export default function moduleForApp(name, description, callbacks) {
+  if (typeof description === 'object') {
+    callbacks = description;
+    description = '';
+  }
+
+  var fullName = ['acceptance', name, (description || '')].join(':');
+
+  callbacks = callbacks || {};
+
+  var _callbacks = {
+    setup: function() {
+      this.App = startApp();
+      this.url = getUrlGenerator(this.App, name);
+
+      (callbacks.setup || function(){}).call(this);
+    },
+    teardown: function() {
+      (callbacks.teardown || function(){}).call(this);
+
+      Ember.run(this.App, 'destroy');
+
+      Ember.$('#ember-testing').empty();
+    }
+  };
+
+  QUnit.module(fullName, _callbacks);
+}


### PR DESCRIPTION
In addition to calling `startApp` this automatically cleans up the new app instance that is returned with `Ember.run(this.App, 'destroy');`. This lends some symmetry between the other moduleForX methods.

Also, we've attached a method `this.url` to the test context. This method makes it easy to create and and then visit routes in tests. `url()` takes either an object that gets interpreted directly by `recognizer.generate` or it will use any arguments that get passed as positional properties to be filled into the url. 
Example:
```
# router.js
App.Router.map(function() {
  this.resource('post', {path: '/posts/:post_slug'});
});

#post.spec.js
test('the page', function() {
  var url = this.url('first-post'); // or `this.url({post_slug: 'first-post'});`
  visit(url);
  ...
});
```