### PR TITLE
Send full stack trace information on promise rejection

### DIFF
--- a/lib/ember-qunit/test.js
+++ b/lib/ember-qunit/test.js
@@ -13,7 +13,13 @@ export default function test(testName, callback) {
     var result = callback.call(context);
 
     function failTestOnPromiseRejection(reason) {
-      ok(false, reason);
+      var message;
+      if (reason instanceof Error) {
+        message = reason.stack;
+      } else {
+        message = Ember.inspect(reason);
+      }
+      ok(false, message);
     }
 
     Ember.run(function(){


### PR DESCRIPTION
This commit solves two issues I was running into:
1. When `reason` is an `Error` (or anything that isn't a string), QUnit would pass it to Testem (used in ember-cli) and Testem would output something not helpful, e.g. `[Object object]`.
2. When the error is passed to QUnit from the `failTestOnPromiseRejection` function, the stack of the original error is lost, making debugging harder.

With this commit, the entire stack trace of an error is sent as the message to QUnit.