### PR TITLE
Pass test callback argument through from QUnit.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "ember-test-helpers": "^0.3.0"
   },
   "devDependencies": {
-    "qunit": "^1.15.0",
+    "qunit": "^1.17.1",
     "loader": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",

--- a/lib/ember-qunit/test.js
+++ b/lib/ember-qunit/test.js
@@ -6,11 +6,11 @@ function resetViews() {
 }
 
 export default function test(testName, callback) {
-  function wrapper() {
+  function wrapper(assert) {
     var context = getContext();
 
     resetViews();
-    var result = callback.call(context);
+    var result = callback.call(context, assert);
 
     function failTestOnPromiseRejection(reason) {
       ok(false, reason);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ember build",
     "prepublish": "bower install",
     "pretest": "ember build",
-    "test": "testem ci",
+    "test": "ember test",
     "start": "ember serve"
   },
   "authors": [
@@ -27,7 +27,6 @@
     "broccoli-sourcemap-concat": "^0.4.3",
     "broccoli-string-replace": "0.0.2",
     "ember-cli": "^0.1.12",
-    "git-repo-info": "^1.0.2",
-    "testem": "0.6.22"
+    "git-repo-info": "^1.0.2"
   }
 }

--- a/testem.json
+++ b/testem.json
@@ -1,12 +1,7 @@
 {
   "framework": "qunit",
   "cwd": "build/",
-  "serve_files": [
-    "assets/loader.js",
-    "assets/vendor.js",
-    "assets/ember-qunit-tests.amd.js",
-    "assets/test-support.js"
-  ],
+  "test_page": "tests/index.html?hidepassed",
   "launch_in_ci": ["PhantomJS"],
   "launch_in_dev": ["PhantomJS", "Chrome"]
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -8,10 +8,12 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
+
   <script src="/assets/vendor.js"></script>
   <script src="/assets/qunit.js"></script>
   <script src="/assets/loader.js"></script>
   <script src="/assets/ember-qunit-tests.amd.js"></script>
   <script src="/assets/test-support.js"></script>
+  <script src="/testem.js"></script>
 </body>
 </html>

--- a/tests/module-for-test.js
+++ b/tests/module-for-test.js
@@ -46,7 +46,7 @@ test("setup callbacks called in the correct order", function() {
   deepEqual(callbackOrder, [ 'beforeSetup', 'setup' ]);
 });
 
-moduleFor('component:x-foo', 'TestModule callbacks', {
+moduleFor('component:x-foo', 'beforeEach/afterEach callbacks', {
   beforeSetup: function() {
     beforeSetupContext = this;
     callbackOrder = [ 'beforeSetup' ];
@@ -70,4 +70,14 @@ moduleFor('component:x-foo', 'TestModule callbacks', {
 
 test("setup callbacks called in the correct order", function() {
   deepEqual(callbackOrder, [ 'beforeSetup', 'beforeEach' ]);
+});
+
+moduleFor('component:x-foo', 'test callback argument', {
+  beforeSetup: setupRegistry
+});
+
+test('callback receives assert argument', function(assert) {
+  assert.expect(1);
+
+  assert.ok(!!assert, 'assert argument was present');
 });


### PR DESCRIPTION
Allows the following (suggested in http://qunitjs.com/upgrade-guide-2.x/):

```javascript
import { test } from 'ember-qunit';

test('confirm stuff', function(assert) {
  assert.expect(1);

  assert.ok(true, 'it works!!!');
});
```