### PR TITLE
Use git-repo-version instead of git-repo-info directly.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -4,7 +4,7 @@ var mergeTrees = require('broccoli-merge-trees');
 var compileES6 = require('broccoli-es6modules');
 var jshintTree = require('broccoli-jshint');
 var replace    = require('broccoli-string-replace');
-var gitInfo    = require('git-repo-info');
+var gitVersion = require('git-repo-version');
 
 // --- Compile ES6 modules ---
 
@@ -61,7 +61,8 @@ generatedBowerConfig = replace(generatedBowerConfig, {
   pattern: {
     match: /VERSION_PLACEHOLDER/,
     replacement: function() {
-      return gitInfo().abbreviatedSha;
+      // remove leading `v` (since by default our tags use a `v` prefix)
+      return gitVersion().replace(/^v/, '');
     }
   }
 });

--- a/build-support/bower.json
+++ b/build-support/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-qunit",
-  "version": "0.2.3+pre.VERSION_PLACEHOLDER",
+  "version": "VERSION_PLACEHOLDER",
   "authors": [
     "Stefan Penner",
     "Ryan Florence",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "broccoli-sourcemap-concat": "^0.4.3",
     "broccoli-string-replace": "0.0.2",
     "ember-cli": "^0.1.12",
-    "git-repo-info": "^1.0.2"
+    "git-repo-version": "^0.1.1"
   }
 }


### PR DESCRIPTION
[git-repo-version](https://github.com/cibernox/git-repo-version) automatically combines the `package.json` version with the current SHA, unless the current SHA also has a tag associated with it.

This removes to need to hand edit the `build-support/bower.json` file for every version bump.

@dgeb - You will almost certainly want to follow suit. It makes releasing much easier (and lessens commit noise).