### PR TITLE
Add qunit ES6 shim.

### DIFF
--- a/lib/ember-qunit/qunit-module.js
+++ b/lib/ember-qunit/qunit-module.js
@@ -1,3 +1,5 @@
+import { module as qunitModule } from 'qunit';
+
 function normalizeCallbacks(callbacks) {
   if (typeof callbacks !== 'object') { return; }
   if (!callbacks) { return; }
@@ -18,7 +20,7 @@ export function createModule(Constructor, name, description, callbacks) {
 
   var module = new Constructor(name, description, callbacks);
 
-  QUnit.module(module.name, {
+  qunitModule(module.name, {
     setup: function() {
       module.setup();
     },

--- a/lib/ember-qunit/test.js
+++ b/lib/ember-qunit/test.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { getContext } from 'ember-test-helpers';
+import { test as qunitTest } from 'qunit';
 
 function resetViews() {
   Ember.View.views = {};
@@ -22,5 +23,5 @@ export default function test(testName, callback) {
     });
   }
 
-  QUnit.test(testName, wrapper);
+  qunitTest(testName, wrapper);
 }

--- a/lib/qunit.js
+++ b/lib/qunit.js
@@ -1,0 +1,4 @@
+/* globals test:true */
+
+export var module = QUnit.module;
+export var test = QUnit.test;

--- a/tests/qunit-shim-test.js
+++ b/tests/qunit-shim-test.js
@@ -1,0 +1,10 @@
+import {
+  module,
+  test
+} from 'qunit';
+
+module('qunit-shim test');
+
+test('should work!', function(assert) {
+  assert.ok('shims should function properly');
+});


### PR DESCRIPTION
We already provide custom module based shims for unit tests, but you
would still have to use the global for acceptance tests.

This allows the following:

```javascript
import { module, test } from 'qunit';
```