### PR TITLE
Update ember-test-helpers to 0.3.6.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "ember": "^1.10.0",
-    "ember-test-helpers": "^0.3.5"
+    "ember-test-helpers": "^0.3.6"
   },
   "devDependencies": {
     "qunit": "^1.17.1",

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "ember": "^1.10.0",
-    "ember-test-helpers": "^0.3.4"
+    "ember-test-helpers": "^0.3.5"
   },
   "devDependencies": {
     "qunit": "^1.17.1",


### PR DESCRIPTION
v0.3.5 fixes a number of normalization issues.
v0.3.6 adds `integration: true` flag for `moduleFor`, `moduleForComponent`, and `moduleForModel`.

Closes #108.
Closes #74.