### PR TITLE
Update ember-test-helpers to 0.4.1.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "ember": "^1.10.0",
-    "ember-test-helpers": "^0.3.6"
+    "ember-test-helpers": "^0.4.1"
   },
   "devDependencies": {
     "qunit": "^1.17.1",


### PR DESCRIPTION
* Fixes issue with `moduleForModel` incorrctly sharing `this.store()` and `this.subject()` across tests.
* Changes `moduleForComponent`'s `this.render()` to no longer returns the view's element (you must call `this.$()` or `this.subject().$()`).