### PR TITLE
Asynchronous module hooks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "ember": "^1.10.0",
-    "ember-test-helpers": "^0.4.1"
+    "ember-test-helpers": "ef4/ember-test-helpers#async-module-hooks"
   },
   "devDependencies": {
     "qunit": "^1.17.1",

--- a/lib/ember-qunit/qunit-module.js
+++ b/lib/ember-qunit/qunit-module.js
@@ -46,19 +46,20 @@ export function createModule(Constructor, name, description, callbacks) {
 
   qunitModule(module.name, {
     setup: function(assert) {
-      module.setup();
-
-      if (beforeEach) {
-        beforeEach.call(module.context, assert);
-      }
+      var done = assert.async();
+      module.setup().then(function() {
+        if (beforeEach) {
+          beforeEach.call(module.context, assert);
+        }
+      })['finally'](done);
     },
 
     teardown: function(assert) {
       if (afterEach) {
         afterEach.call(module.context, assert);
       }
-
-      module.teardown();
+      var done = assert.async();
+      module.teardown()['finally'](done);
     }
   });
 }

--- a/tests/module-for-test.js
+++ b/tests/module-for-test.js
@@ -48,6 +48,7 @@ test("setup callbacks called in the correct order", function() {
 
 moduleFor('component:x-foo', 'beforeEach/afterEach callbacks', {
   beforeSetup: function() {
+    setupRegistry();
     beforeSetupContext = this;
     callbackOrder = [ 'beforeSetup' ];
   },


### PR DESCRIPTION
This makes ember-qunit compatible with my PR to ember-test-helpers (https://github.com/switchfly/ember-test-helpers/pull/32) that switches module hooks from sync to async.