### PR TITLE
Remove dubious `resetViews` function

### DIFF
--- a/lib/ember-qunit/test.js
+++ b/lib/ember-qunit/test.js
@@ -2,15 +2,10 @@ import Ember from 'ember';
 import { getContext } from 'ember-test-helpers';
 import { test as qunitTest } from 'qunit';
 
-function resetViews() {
-  Ember.View.views = {};
-}
-
 export default function test(testName, callback) {
   function wrapper(assert) {
     var context = getContext();
 
-    resetViews();
     var result = callback.call(context, assert);
 
     function failTestOnPromiseRejection(reason) {


### PR DESCRIPTION
This resolves #86.

I don't think there can possibly be a good reason for this function to be here. Even if it is desirable to clean up pre-existing views at the start of each test, this is not the right way to do it -- it just breaks their event handling while leaving them otherwise intact.