### PR TITLE
Update ember-test-helpers to 0.5.0.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "ember": "^1.10.0",
-    "ember-test-helpers": "^0.4.6"
+    "ember-test-helpers": "^0.5.0"
   },
   "devDependencies": {
     "qunit": "^1.17.1",


### PR DESCRIPTION
Completely refactors the isolated container instantiation, to allow for
all default Ember and Ember Data container contents.

Should not be a breaking change, but since this is a relatively large change
we will be bumping our minor version when publishing this.