### PR TITLE
Better exception messages on phantomjs

### DIFF
--- a/lib/ember-qunit/test.js
+++ b/lib/ember-qunit/test.js
@@ -12,6 +12,11 @@ export default function test(testName, callback) {
       var message;
       if (reason instanceof Error) {
         message = reason.stack;
+        if (reason.message && message.indexOf(reason.message) < 0) {
+          // PhantomJS has a `stack` that does not contain the actual
+          // exception message.
+          message = Ember.inspect(reason) + "\n" + message;
+        }
       } else {
         message = Ember.inspect(reason);
       }


### PR DESCRIPTION
Exceptions on phantomjs have a `stack` property that does not contain
the exception message itself. Which causes us to print only the stack
without the actual error message whenever a test returns a rejected promise.

This change ensures that the error message must appear within our output.

I'm not sure how to test this -- mocking out `ok` while also using `ok`
seems very headsplody.