### PR TITLE
Remove redundant build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "ember build",
     "prepublish": "bower install",
-    "pretest": "ember build",
     "test": "ember test",
     "start": "ember serve"
   },


### PR DESCRIPTION
AFAIK this is unnecessary, and we're building twice during test runs.