### PR TITLE
Imports QUnit.only a new feature in QUnit 1.20

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "ember-test-helpers": "^0.5.14"
   },
   "devDependencies": {
-    "qunit": "^1.17.1",
+    "qunit": "^1.20.0",
     "loader": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",

--- a/lib/qunit.js
+++ b/lib/qunit.js
@@ -3,5 +3,6 @@
 export var module = QUnit.module;
 export var test = QUnit.test;
 export var skip = QUnit.skip;
+export var only = QUnit.only;
 
 export default QUnit;

--- a/tests/qunit-shim-test.js
+++ b/tests/qunit-shim-test.js
@@ -1,7 +1,8 @@
 import {
   module,
   test,
-  skip
+  skip,
+  only
 } from 'qunit';
 
 module('qunit-shim test');
@@ -12,4 +13,8 @@ test('should work!', function(assert) {
 
 test('imports skips', function(assert) {
   assert.equal(typeof skip, 'function', 'imports QUnit.skip');
+});
+
+test('imports only', function(assert) {
+  assert.equal(typeof only, 'function', 'imports QUnit.only');
 });


### PR DESCRIPTION
With the new 1.20 release, [QUnit.only](https://api.qunitjs.com/QUnit.only/) should be exposed for focusing test runs.