### PR TITLE
[RFC] Adds a wrapped QUnit.only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components
 tmp
 dist
 build
+*.log

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "ember-test-helpers": "^0.5.14"
   },
   "devDependencies": {
-    "qunit": "^1.17.1",
+    "qunit": "^1.20.0",
     "loader": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",

--- a/lib/ember-qunit.js
+++ b/lib/ember-qunit.js
@@ -2,6 +2,7 @@ import moduleFor          from 'ember-qunit/module-for';
 import moduleForComponent from 'ember-qunit/module-for-component';
 import moduleForModel     from 'ember-qunit/module-for-model';
 import test               from 'ember-qunit/test';
+import only               from 'ember-qunit/only';
 import { setResolver }    from 'ember-test-helpers';
 
 export {
@@ -9,5 +10,6 @@ export {
   moduleForComponent,
   moduleForModel,
   test,
+  only,
   setResolver
 };

--- a/lib/ember-qunit/only.js
+++ b/lib/ember-qunit/only.js
@@ -1,0 +1,6 @@
+import testWrapper from 'ember-qunit/test-wrapper';
+import { only as qunitOnly } from 'qunit';
+
+export default function only(testName, callback) {
+  testWrapper(testName, callback, qunitOnly);
+}

--- a/lib/ember-qunit/test-wrapper.js
+++ b/lib/ember-qunit/test-wrapper.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+import { getContext } from 'ember-test-helpers';
+
+export default function testWrapper(testName, callback, qunit) {
+  function wrapper(assert) {
+    var context = getContext();
+
+    var result = callback.call(context, assert);
+
+    function failTestOnPromiseRejection(reason) {
+      var message;
+      if (reason instanceof Error) {
+        message = reason.stack;
+        if (reason.message && message.indexOf(reason.message) < 0) {
+          // PhantomJS has a `stack` that does not contain the actual
+          // exception message.
+          message = Ember.inspect(reason) + "\n" + message;
+        }
+      } else {
+        message = Ember.inspect(reason);
+      }
+      ok(false, message);
+    }
+
+    Ember.run(function(){
+      QUnit.stop();
+      Ember.RSVP.Promise.resolve(result)['catch'](failTestOnPromiseRejection)['finally'](QUnit.start);
+    });
+  }
+
+  qunit(testName, wrapper);
+}

--- a/lib/ember-qunit/test.js
+++ b/lib/ember-qunit/test.js
@@ -1,33 +1,6 @@
-import Ember from 'ember';
-import { getContext } from 'ember-test-helpers';
+import testWrapper from 'ember-qunit/test-wrapper';
 import { test as qunitTest } from 'qunit';
 
 export default function test(testName, callback) {
-  function wrapper(assert) {
-    var context = getContext();
-
-    var result = callback.call(context, assert);
-
-    function failTestOnPromiseRejection(reason) {
-      var message;
-      if (reason instanceof Error) {
-        message = reason.stack;
-        if (reason.message && message.indexOf(reason.message) < 0) {
-          // PhantomJS has a `stack` that does not contain the actual
-          // exception message.
-          message = Ember.inspect(reason) + "\n" + message;
-        }
-      } else {
-        message = Ember.inspect(reason);
-      }
-      ok(false, message);
-    }
-
-    Ember.run(function(){
-      QUnit.stop();
-      Ember.RSVP.Promise.resolve(result)['catch'](failTestOnPromiseRejection)['finally'](QUnit.start);
-    });
-  }
-
-  qunitTest(testName, wrapper);
+  testWrapper(testName, callback, qunitTest);
 }

--- a/lib/qunit.js
+++ b/lib/qunit.js
@@ -3,5 +3,6 @@
 export var module = QUnit.module;
 export var test = QUnit.test;
 export var skip = QUnit.skip;
+export var only = QUnit.only;
 
 export default QUnit;

--- a/tests/qunit-shim-test.js
+++ b/tests/qunit-shim-test.js
@@ -1,7 +1,8 @@
 import {
   module,
   test,
-  skip
+  skip,
+  only
 } from 'qunit';
 
 module('qunit-shim test');
@@ -12,4 +13,8 @@ test('should work!', function(assert) {
 
 test('imports skips', function(assert) {
   assert.equal(typeof skip, 'function', 'imports QUnit.skip');
+});
+
+test('imports only', function(assert) {
+  assert.equal(typeof only, 'function', 'imports QUnit.only');
 });


### PR DESCRIPTION
Adds support for Qunit's [only](https://api.qunitjs.com/QUnit.only/) function for focusing test runs. I'd love some hints on how to test this as the test run itself needs to be separated from the existing test runs. We accomplished this in QUnit via a separate suite, but I'm not sure how to get that working in a Broccoli build. Any tips would be greatly appreciated.

Thanks again to @the83 for reviewing this for me.