### PR TITLE
Make test context available as a param

### DIFF
--- a/lib/ember-qunit/qunit-module.js
+++ b/lib/ember-qunit/qunit-module.js
@@ -49,14 +49,14 @@ export function createModule(Constructor, name, description, callbacks) {
       var done = assert.async();
       return module.setup().then(function() {
         if (beforeEach) {
-          beforeEach.call(module.context, assert);
+          beforeEach.call(module.context, assert, module.context);
         }
       })['finally'](done);
     },
 
     teardown: function(assert) {
       if (afterEach) {
-        afterEach.call(module.context, assert);
+        afterEach.call(module.context, assert, module.context);
       }
       var done = assert.async();
       return module.teardown()['finally'](done);

--- a/lib/ember-qunit/test-wrapper.js
+++ b/lib/ember-qunit/test-wrapper.js
@@ -9,8 +9,11 @@ export default function testWrapper(qunit /*, testName, expected, callback, asyn
 
   function wrapper() {
     var context = getContext();
+    var args = Array.prototype.slice.call(arguments, 0);
 
-    var result = callback.apply(context, arguments);
+    args.push(context);
+
+    var result = callback.apply(context, args);
 
     function failTestOnPromiseRejection(reason) {
       var message;

--- a/tests/module-for-test.js
+++ b/tests/module-for-test.js
@@ -17,19 +17,21 @@ moduleFor('component:x-foo', 'TestModule callbacks', {
     setupRegistry();
   },
 
-  setup: function() {
+  setup: function(assert, context) {
     setupContext = this;
     callbackOrder.push('setup');
 
     ok(setupContext !== beforeSetupContext);
+    equal(setupContext, context);
   },
 
-  teardown: function() {
+  teardown: function(assert, context) {
     teardownContext = this;
     callbackOrder.push('teardown');
 
     deepEqual(callbackOrder, [ 'beforeSetup', 'setup', 'teardown']);
     equal(setupContext, teardownContext);
+    equal(setupContext, context);
   },
 
   afterTeardown: function() {
@@ -110,4 +112,8 @@ test('assert argument is not shared between tests', function(assert) {
 
   assert.ok(!!assert, 'assert argument was present');
   assert.ok(true, 'dummy extra test');
+});
+
+test('context is available as a second param', function(assert, context) {
+  assert.equal(this, context);
 });


### PR DESCRIPTION
I'd like to remove all cases of `this` from my Ember test suite.

Why? It might be confusing to get `assert` passed as param and having
to use `this` to access the context. Making it a param also makes it
more semantic, because you will be naming it for what it is: `context`.

Bonus: being able to use arrow functions.