### PR TITLE
Export QUnit.skip

### DIFF
--- a/lib/ember-qunit.js
+++ b/lib/ember-qunit.js
@@ -3,6 +3,7 @@ import moduleForComponent from 'ember-qunit/module-for-component';
 import moduleForModel     from 'ember-qunit/module-for-model';
 import test               from 'ember-qunit/test';
 import only               from 'ember-qunit/only';
+import skip               from 'ember-qunit/skip';
 import { setResolver }    from 'ember-test-helpers';
 
 export {
@@ -11,5 +12,6 @@ export {
   moduleForModel,
   test,
   only,
+  skip,
   setResolver
 };

--- a/lib/ember-qunit/skip.js
+++ b/lib/ember-qunit/skip.js
@@ -1,0 +1,10 @@
+import testWrapper from 'ember-qunit/test-wrapper';
+import { skip as qunitSkip } from 'qunit';
+
+export default function skip(/* testName, expected, callback, async */) {
+  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; ++_key) {
+    args[_key] = arguments[_key];
+  }
+  args.unshift(qunitSkip);
+  testWrapper.apply(null, args);
+}


### PR DESCRIPTION
Exposes QUnit.skip() for use in ember test suites.

It looks like this was partially implemented already; `lib/qunit.js` exported it and and `tests/qunit-shim-tests.js` tested for its presence. However, it was not wrapped or exported by ember-qunit, like `only` and `test` are. 