### PR TITLE
install bower components the correct directory

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
This makes sure an unexpected `.bowerrc` file in a parent directory won't be used on accident when executing `bower install`. In my case one was found that was making components install to "app/bower_components". 