### PR TITLE
Upgrade package versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,14 +15,14 @@
     "tests"
   ],
   "dependencies": {
-    "ember": "^1.10.0"
+    "ember": "^1.13.13"
   },
   "devDependencies": {
-    "qunit": "^1.20.0",
-    "loader": "stefanpenner/loader.js#1.0.1",
-    "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
-    "jquery": "~2.1.1",
+    "qunit": "^1.23.1",
+    "loader": "ember-cli/loader.js#1.0.1",
+    "ember-cli-shims": "0.0.3",
+    "ember-cli-test-loader": "0.0.4",
+    "jquery": "~2.1.4",
     "ember-data": "~1.0.0-beta.10"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -16,22 +16,22 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "ember-test-helpers": "^0.5.22"
+    "ember-test-helpers": "^0.5.30"
   },
   "devDependencies": {
     "bower": "^1.3.12",
-    "broccoli": "^0.13.0",
+    "broccoli": "^0.16.9",
     "broccoli-babel-transpiler": "^5.5.0",
-    "broccoli-funnel": "^0.1.6",
-    "broccoli-jshint": "^0.5.3",
-    "broccoli-merge-trees": "^0.1.4",
-    "broccoli-sourcemap-concat": "^0.4.3",
+    "broccoli-funnel": "^0.2.15",
+    "broccoli-jshint": "^0.5.8",
+    "broccoli-merge-trees": "^0.2.4",
+    "broccoli-sourcemap-concat": "^0.4.4",
     "broccoli-string-replace": "0.0.2",
-    "ember-cli": "^0.1.12",
-    "ember-cli-release": "^0.2.7",
+    "ember-cli": "^0.2.7",
+    "ember-cli-release": "^0.2.9",
     "exists-sync": "0.0.3",
-    "git-repo-version": "^0.1.2",
-    "resolve": "^1.1.6"
+    "git-repo-version": "^0.3.1",
+    "resolve": "^1.1.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This update increases all package versions within their currently set range. Specifically, the bump to ember-test-helpers will avoid users from being trolled by their CI cache due to recent changes in that package & Ember.

/cc @rwjblue 