### PR TITLE
Use QUnit's test context during test runs.

### DIFF
--- a/lib/ember-qunit/qunit-module.js
+++ b/lib/ember-qunit/qunit-module.js
@@ -47,16 +47,20 @@ export function createModule(Constructor, name, description, callbacks) {
   qunitModule(module.name, {
     setup: function(assert) {
       var done = assert.async();
-      return module.setup().then(function() {
+      return module.setup().then(() => {
+        Object.keys(module.context).forEach(key => {
+          this[key] = module.context[key];
+        });
+
         if (beforeEach) {
-          beforeEach.call(module.context, assert);
+          beforeEach.call(this, assert);
         }
       })['finally'](done);
     },
 
     teardown: function(assert) {
       if (afterEach) {
-        afterEach.call(module.context, assert);
+        afterEach.call(this, assert);
       }
       var done = assert.async();
       return module.teardown()['finally'](done);

--- a/lib/ember-qunit/test-wrapper.js
+++ b/lib/ember-qunit/test-wrapper.js
@@ -10,7 +10,11 @@ export default function testWrapper(qunit /*, testName, expected, callback, asyn
   function wrapper() {
     var context = getContext();
 
-    var result = callback.apply(context, arguments);
+    Object.keys(context).forEach(key => {
+      this[key] = context[key];
+    });
+
+    var result = callback.apply(this, arguments);
 
     function failTestOnPromiseRejection(reason) {
       var message;


### PR DESCRIPTION
I'm opening this as a PR, because it demonstrates a proof of concept, but this should be treated as an issue for discussion.

I have some code that collects information on the `this` supplied to each QUnit test for processing inside of [QUnit.done](https://api.qunitjs.com/QUnit.done/). Currently, the test wrappers hide that context from the tests. The commit in this PR tries to solve the problem following what is done in #234, and I've verified that it resolves my use case.

However, I don't know if this will break backwards compatibility in an unexpected way, so I'm open to other strategies as well. Happy to implement whatever falls out of this discussion if necessary.

/cc @trentmwillis, @step2yeung